### PR TITLE
Fix cutoff char bug && add theme feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = function(settings) {
     var jade = require('jade'),
         path = require('path'),
         fs = require('fs'),
+        theme = null,
         template = path.join(__dirname, 'toolbar.jade'),
 
         script = fs.readFileSync(path.join(__dirname, 'assets', 'js.js'), 'utf-8'),
@@ -11,6 +12,9 @@ module.exports = function(settings) {
     settings = settings || {};
     settings.depth = settings.depth || 4;
 
+    if (settings.theme) {
+        theme = fs.readFileSync(settings.theme, 'utf-8');
+    }
 
     var isAbsolute = function(path){
         return ('/' === path[0]) || (':' === path[1] && '\\' === path[2]);
@@ -91,7 +95,8 @@ module.exports = function(settings) {
                 req_safe: req_safe,
                 settings: settings,
                 script: script,
-                style: style
+                style: style,
+                theme: theme
             };
 
             jade.renderFile(template, opts, function(err, toolbar) {

--- a/toolbar.jade
+++ b/toolbar.jade
@@ -1,5 +1,8 @@
 style(type='text/css')!=style
 
+- if (theme)
+  style(type='text/css')!=theme
+
 mixin print_val(val, depth)
     - if (val === undefined)
         span.undefined undefined


### PR DESCRIPTION
## Cutoff character bug

With a simple jade template, `layout.jade`:

```
doctype 5
html
  body
```

And a simple render:

```
exports.index = (req, res) ->
  res.render 'layout'
```

The html that results after mixing in the EDT markup cuts off the closing bracket of the starting body tag, looking in part like this:

```
<!DOCTYPE html><html><body<style type="text/css">/* SHOW/HIDE buttons */
#EDT-show {
...
```
## Theme feature

Added ability to pass in css as a theme to override the default css.  Used like:

```
settings = { theme: path.join(__dirname, 'static, 'css', 'express-debug.css') };
app.use(require('express-debug')(settings));        
```

Sorry these came together in one pull request.  I should have feature branched.
