### PR TITLE
App won't work if app.use(app.router) is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ for proper structure, each panel is an object
 
 `nav` - links to every GET route in your app. (not a default panel)
 
+### Caveats
+* This module will not work if you explicitly define `app.use(app.router);`
 
 ### Future
 * optional error page that prints better stacks


### PR DESCRIPTION
I found your module really useful but I ran into a snag trying to figure out why it wasn't working. As the title says, things won't work properly if app.use(app.router) is defined so I updated the README with that information in the hopes of saving someone else some time.
