### PR TITLE
fixup: res.render(view, opts, callback), callback broken

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -88,10 +88,6 @@ response.init = function(app, settings) {
                 console.log(err);
                 req.next(err);
 
-                // skip if this client req isn't expecting html or is ajax
-            } else if (accept.indexOf('html') === -1 ||  req.xhr) {
-                res.send(str);
-
             } else if (res.EDT_rendered) {
                 // if callback method was used, more than one template may be rendered.
                 // in this care, do not render another copy


### PR DESCRIPTION
I have reviewed the code, line 91-94 is not necessary at all, and it break res.render callback.
